### PR TITLE
Read from master flag should be a global variable

### DIFF
--- a/lib/active_record_replica/active_record_replica.rb
+++ b/lib/active_record_replica/active_record_replica.rb
@@ -18,6 +18,13 @@ module ActiveRecordReplica
       return
     end
 
+    # When the DBMS is not available, an exception (e.g. PG::ConnectionBad) is raised
+    active_db_connection = ActiveRecord::Base.connection.active? rescue false
+    unless active_db_connection
+      ActiveRecord::Base.logger.info("ActiveRecord not connected so not installing ActiveRecordReplica")
+      return
+    end
+
     version = ActiveRecordReplica::VERSION
     ActiveRecord::Base.logger.info("ActiveRecordReplica.install! v#{version} Establishing connection to replica database")
     Replica.establish_connection(replica_config)

--- a/lib/active_record_replica/extensions.rb
+++ b/lib/active_record_replica/extensions.rb
@@ -3,7 +3,7 @@ module ActiveRecordReplica
   module Extensions
     extend ActiveSupport::Concern
 
-    ActiveRecordReplica::SELECT_METHODS.each do |select_method|
+    [:select, :select_all, :select_one, :select_rows, :select_value, :select_values].each do |select_method|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{select_method}(sql, name = nil, *args)
           return super if active_record_replica_read_from_primary?

--- a/lib/active_record_replica/version.rb
+++ b/lib/active_record_replica/version.rb
@@ -1,3 +1,3 @@
 module ActiveRecordReplica
-  VERSION = '2.1.0'
+  VERSION = '3.0.0'
 end

--- a/lib/active_record_replica/version.rb
+++ b/lib/active_record_replica/version.rb
@@ -1,3 +1,3 @@
 module ActiveRecordReplica
-  VERSION = '2.0.2'
+  VERSION = '2.1.0'
 end

--- a/test/active_record_replica_test.rb
+++ b/test/active_record_replica_test.rb
@@ -1,93 +1,43 @@
-require File.join(File.dirname(__FILE__), 'test_helper')
-require 'logger'
-require 'erb'
+# frozen_string_literal: true
 
-l                                 = Logger.new('test.log')
-l.level                           = ::Logger::DEBUG
-ActiveRecord::Base.logger         = l
-ActiveRecord::Base.configurations = YAML::load(ERB.new(IO.read('test/database.yml')).result)
-
-# Define Schema in second database (replica)
-# Note: This is not be required when the primary database is being replicated to the replica db
-ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test']['replica'])
-
-# Create table users in database active_record_replica_test
-ActiveRecord::Schema.define :version => 0 do
-  create_table :users, :force => true do |t|
-    t.string :name
-    t.string :address
-  end
-end
-
-# Define Schema in primary database
-ActiveRecord::Base.establish_connection(:test)
-
-# Create table users in database active_record_replica_test
-ActiveRecord::Schema.define :version => 0 do
-  create_table :users, :force => true do |t|
-    t.string :name
-    t.string :address
-  end
-end
-
-# AR Model
-class User < ActiveRecord::Base
-end
-
-# Install ActiveRecord replica. Done automatically by railtie in a Rails environment
-# Also tell it to use the test environment since Rails.env is not available
-ActiveRecordReplica.install!(nil, 'test')
+require_relative "test_helper"
 
 #
 # Unit Test for active_record_replica
 #
-# Since their is no database replication in this test environment, it will
+# Since there is no database replication in this test environment, it will
 # use 2 separate databases. Writes go to the first database and reads to the second.
 # As a result any writes to the first database will not be visible when trying to read from
 # the second test database.
+#
+# The tests verify that reads going to the replica database do not find data written to the primary.
 class ActiveRecordReplicaTest < Minitest::Test
-  describe 'the active_record_replica gem' do
+  describe "the active_record_replica gem" do
+    let(:user_name) { "Joe Bloggs" }
+    let(:address) { "Somewhere" }
+    let(:user) { User.new(name: user_name, address: address) }
 
     before do
       ActiveRecordReplica.ignore_transactions = false
-
-      User.delete_all
-
-      @name    = "Joe Bloggs"
-      @address = "Somewhere"
-      @user    = User.new(
-        :name    => @name,
-        :address => @address
-      )
-    end
-
-    after do
       User.delete_all
     end
 
-    it 'saves to primary' do
-      assert_equal true, @user.save!
+    it "saves to primary" do
+      user.save!
     end
 
-    #
-    # NOTE:
-    #
-    #   There is no automated replication between the SQL lite databases
-    #   so the tests will be verifying that reads going to the "replica" (second)
-    #   database do not find data written to the primary.
-    #
-    it 'saves to primary, read from replica' do
+    it "saves to primary, read from replica" do
       # Read from replica
-      assert_equal 0, User.where(:name => @name, :address => @address).count
+      assert_equal 0, User.where(name: user_name, address: address).count
 
       # Write to primary
-      assert_equal true, @user.save!
+      user.save!
 
       # Read from replica
-      assert_equal 0, User.where(:name => @name, :address => @address).count
+      assert_equal 0, User.where(name: user_name, address: address).count
     end
 
-    it 'save to primary, read from primary when in a transaction' do
+    it "save to primary, read from primary when in a transaction" do
       assert_equal false, ActiveRecordReplica.ignore_transactions?
 
       User.transaction do
@@ -95,56 +45,55 @@ class ActiveRecordReplicaTest < Minitest::Test
         assert_equal 0, User.count
 
         # Read from Primary
-        assert_equal 0, User.where(:name => @name, :address => @address).count
+        assert_equal 0, User.where(name: user_name, address: address).count
 
         # Write to primary
-        assert_equal true, @user.save!
+        user.save!
 
         # Read from Primary
-        assert_equal 1, User.where(:name => @name, :address => @address).count
+        assert_equal 1, User.where(name: user_name, address: address).count
       end
 
       # Read from Non-replicated replica
-      assert_equal 0, User.where(:name => @name, :address => @address).count
+      assert_equal 0, User.where(name: user_name, address: address).count
     end
 
-    it 'save to primary, read from replica when ignoring transactions' do
+    it "save to primary, read from replica when ignoring transactions" do
       ActiveRecordReplica.ignore_transactions = true
-      assert_equal true, ActiveRecordReplica.ignore_transactions?
+      assert ActiveRecordReplica.ignore_transactions?
 
       User.transaction do
         # The delete_all in setup should have cleared the table
         assert_equal 0, User.count
 
         # Read from Primary
-        assert_equal 0, User.where(:name => @name, :address => @address).count
+        assert_equal 0, User.where(name: user_name, address: address).count
 
         # Write to primary
-        assert_equal true, @user.save!
+        user.save!
 
         # Read from Non-replicated replica
-        assert_equal 0, User.where(:name => @name, :address => @address).count
+        assert_equal 0, User.where(name: user_name, address: address).count
       end
 
       # Read from Non-replicated replica
-      assert_equal 0, User.where(:name => @name, :address => @address).count
+      assert_equal 0, User.where(name: user_name, address: address).count
     end
 
-    it 'saves to primary, force a read from primary even when _not_ in a transaction' do
+    it "saves to primary, force a read from primary even when _not_ in a transaction" do
       # Read from replica
-      assert_equal 0, User.where(:name => @name, :address => @address).count
+      assert_equal 0, User.where(name: user_name, address: address).count
 
       # Write to primary
-      assert_equal true, @user.save!
+      user.save!
 
       # Read from replica
-      assert_equal 0, User.where(:name => @name, :address => @address).count
+      assert_equal 0, User.where(name: user_name, address: address).count
 
       # Read from Primary
       ActiveRecordReplica.read_from_primary do
-        assert_equal 1, User.where(:name => @name, :address => @address).count
+        assert_equal 1, User.where(name: user_name, address: address).count
       end
     end
-
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,41 @@ require 'active_record'
 require 'minitest/autorun'
 require 'active_record_replica'
 require 'awesome_print'
+require 'logger'
+require 'erb'
+
+l                                 = Logger.new('test.log')
+l.level                           = ::Logger::DEBUG
+ActiveRecord::Base.logger         = l
+ActiveRecord::Base.configurations = YAML::load(ERB.new(IO.read('test/database.yml')).result)
+
+# Define Schema in second database (replica)
+# Note: This is not be required when the primary database is being replicated to the replica db
+ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test']['replica'])
+
+# Create table users in database active_record_replica_test
+ActiveRecord::Schema.define :version => 0 do
+  create_table :users, :force => true do |t|
+    t.string :name
+    t.string :address
+  end
+end
+
+# Define Schema in primary database
+ActiveRecord::Base.establish_connection(:test)
+
+# Create table users in database active_record_replica_test
+ActiveRecord::Schema.define :version => 0 do
+  create_table :users, :force => true do |t|
+    t.string :name
+    t.string :address
+  end
+end
+
+# AR Model
+class User < ActiveRecord::Base
+end
+
+# Install ActiveRecord replica. Done automatically by railtie in a Rails environment
+# Also tell it to use the test environment since Rails.env is not available
+ActiveRecordReplica.install!(nil, 'test')


### PR DESCRIPTION
### Issue # (if available)

Fixes #5, #10, and #20

### Description of changes

- read_from_master! is supposed to be a global and not thread specific variable.
- Use ActiveRecord::Base.configurations so that Active Record Replica can be disabled when the relevant database has not yet been created.
- Don't install when primary database is not available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
